### PR TITLE
Add custom targeting support

### DIFF
--- a/Example/App.js
+++ b/Example/App.js
@@ -139,6 +139,7 @@ export default class Example extends Component {
               adSize="banner"
               validAdSizes={['banner', 'largeBanner', 'mediumRectangle']}
               adUnitID="/6499/example/APIDemo/AdSizes"
+              customTargeting={{ verticals: "entertainment" }}
               ref={el => (this._adSizesExample = el)}
             />
             <Button

--- a/RNPublisherBanner.js
+++ b/RNPublisherBanner.js
@@ -1,4 +1,4 @@
-import { arrayOf, func, string } from 'prop-types';
+import { arrayOf, func, string, object } from 'prop-types';
 import React, { Component } from 'react';
 import {
   findNodeHandle,
@@ -87,6 +87,11 @@ PublisherBanner.propTypes = {
    * banner is default
    */
   adSize: string,
+
+  /**
+   * Provide key/value object of targeting values to send with the request
+   */
+  customTargeting: object,
 
   /**
    * Optional array specifying all valid sizes that are appropriate for this slot.

--- a/ios/RNDFPBannerView.h
+++ b/ios/RNDFPBannerView.h
@@ -12,6 +12,7 @@
 
 @property (nonatomic, copy) NSArray *validAdSizes;
 @property (nonatomic, copy) NSArray *testDevices;
+@property (nonatomic, copy) NSDictionary *customTargeting;
 
 @property (nonatomic, copy) RCTBubblingEventBlock onSizeChange;
 @property (nonatomic, copy) RCTBubblingEventBlock onAppEvent;

--- a/ios/RNDFPBannerView.m
+++ b/ios/RNDFPBannerView.m
@@ -55,6 +55,13 @@
 - (void)loadBanner {
     GADRequest *request = [GADRequest request];
     request.testDevices = _testDevices;
+
+    if (_customTargeting != nil) {
+        if (_customTargeting.count > 0) {
+            request.customTargeting = _customTargeting;
+        }
+    }
+    
     [_bannerView loadRequest:request];
 }
 
@@ -75,6 +82,11 @@
 - (void)setTestDevices:(NSArray *)testDevices
 {
     _testDevices = RNAdMobProcessTestDevices(testDevices, kDFPSimulatorID);
+}
+
+- (void)setCustomTargeting:(NSDictionary *)customTargeting
+{
+    _customTargeting = customTargeting;
 }
 
 -(void)layoutSubviews

--- a/ios/RNDFPBannerViewManager.m
+++ b/ios/RNDFPBannerViewManager.m
@@ -36,6 +36,7 @@ RCT_REMAP_VIEW_PROPERTY(adSize, _bannerView.adSize, GADAdSize)
 RCT_REMAP_VIEW_PROPERTY(adUnitID, _bannerView.adUnitID, NSString)
 RCT_EXPORT_VIEW_PROPERTY(validAdSizes, NSArray)
 RCT_EXPORT_VIEW_PROPERTY(testDevices, NSArray)
+RCT_EXPORT_VIEW_PROPERTY(customTargeting, NSDictionary)
 
 RCT_EXPORT_VIEW_PROPERTY(onSizeChange, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onAppEvent, RCTBubblingEventBlock)


### PR DESCRIPTION
Add support for passing custom targeting attributes to the DFP banner.

Adapted from this commit on another project: https://github.com/shukerullah/react-native-admob-dfp/commit/ac302db65f37e2f8fc2d6dc7578b34c6c3e516b1